### PR TITLE
Add redirecthelper to prepend baseUrl to redirects if present

### DIFF
--- a/src/Gatekeeper.php
+++ b/src/Gatekeeper.php
@@ -23,6 +23,7 @@ use craft\web\View;
 use craft\events\RegisterUrlRulesEvent;
 
 use yii\base\Event;
+use yii\web\Response;
 
 /**
  * TODO:
@@ -143,7 +144,7 @@ class Gatekeeper extends Plugin
                 );
 
                 if ($this->isGuest() && !$this->isAuthenticated() && !$this->isGatekeeperRequest()) {
-                    Craft::$app->getResponse()->redirect('/gatekeeper');
+                    $this->redirectHelper('/gatekeeper');
                 }
             }
         );
@@ -164,6 +165,23 @@ class Gatekeeper extends Plugin
     {
         $url = Craft::$app->getRequest()->getUrl();
         return stripos($url, 'gatekeeper');
+    }
+
+    /**
+     * @param string $location
+     * @return Response
+     */
+    public function redirectHelper(string $location): Response
+    {
+        if (strpos($location, '/') !== 0) {
+            $location = '/' . $location;
+        }
+        $currentSite = Craft::$app->getSites()->getCurrentSite();
+        if ($currentSite->baseUrl) {
+            $baseUrl = Craft::getAlias($currentSite->baseUrl);
+            return Craft::$app->getResponse()->redirect(rtrim($baseUrl, '/') . $location);
+        }
+        return Craft::$app->getResponse()->redirect($location);
     }
 
     /**

--- a/src/controllers/GatekeeperController.php
+++ b/src/controllers/GatekeeperController.php
@@ -55,7 +55,7 @@ class GatekeeperController extends Controller
     public function actionIndex()
     {
         if (Gatekeeper::$plugin->isAuthenticated()) {
-            return $this->redirect('/');
+            Gatekeeper::$plugin->redirectHelper('/');
         }
         
         return $this->renderFrontendTemplate('gatekeeper/_frontend/gatekeeper');
@@ -78,7 +78,7 @@ class GatekeeperController extends Controller
             $cookie->expire = time() + 3600;
             Craft::$app->getResponse()->getCookies()->add($cookie);
 
-            return $this->redirect('/');
+            Gatekeeper::$plugin->redirectHelper('/');
         }
 
         $params['error'] = true;


### PR DESCRIPTION
This PR will prepend all redirects from craft-gatekeeper with baseUrl if this is present on the current site.
Before this change redirects was hardcoded to `/` and `/gatekeeper` which in some cases can lead to 404.