### PR TITLE
Add 'enabled' and 'duration' settings

### DIFF
--- a/src/Gatekeeper.php
+++ b/src/Gatekeeper.php
@@ -136,7 +136,7 @@ class Gatekeeper extends Plugin
                     __METHOD__
                 );
 
-                if ($this->isGuest() && !$this->isAuthenticated() && !$this->isGatekeeperRequest()) {
+                if ($this->settings->enabled && $this->isGuest() && !$this->isAuthenticated() && !$this->isGatekeeperRequest()) {
                     $cookie = new Cookie(['name' => 'gatekeeper_referer']);
                     $cookie->value = Craft::$app->getRequest()->getUrl();
                     $cookie->expire = time() + 30;

--- a/src/Gatekeeper.php
+++ b/src/Gatekeeper.php
@@ -194,10 +194,14 @@ class Gatekeeper extends Plugin
      */
     protected function settingsHtml(): string
     {
+        // Get the settings that are being defined by the config file
+        $overrides = Craft::$app->getConfig()->getConfigFromFile('gatekeeper');
+
         return Craft::$app->view->renderTemplate(
             'gatekeeper/settings',
             [
-                'settings' => $this->getSettings()
+                'settings' => $this->getSettings(),
+                'overrides' => array_keys($overrides),
             ]
         );
     }

--- a/src/config.php
+++ b/src/config.php
@@ -26,5 +26,5 @@ return [
 
     "password" => '',
     "notice" => '',
-
+    "duration" => 3600,
 ];

--- a/src/config.php
+++ b/src/config.php
@@ -23,7 +23,7 @@
  */
 
 return [
-
+    "enabled" => true,
     "password" => '',
     "notice" => '',
     "duration" => 3600,

--- a/src/controllers/GatekeeperController.php
+++ b/src/controllers/GatekeeperController.php
@@ -71,11 +71,12 @@ class GatekeeperController extends Controller
     {
         $password = Craft::$app->getRequest()->post('password');
         $gatekeeperPassword = Gatekeeper::$settings->password;
+        $gatekeeperCookieDuration =  Gatekeeper::$settings->duration;
 
         if ($password === $gatekeeperPassword) {
             $cookie = new Cookie(['name' => 'gatekeeper']);
             $cookie->value = 'loggedin';
-            $cookie->expire = time() + 3600;
+            $cookie->expire = time() + $gatekeeperCookieDuration;
             Craft::$app->getResponse()->getCookies()->add($cookie);
             if ($refererUrl = Craft::$app->getRequest()->getCookies()->get('gatekeeper_referer')) {
                 return $this->redirect($refererUrl->value);

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -39,6 +39,11 @@ class Settings extends Model
      */
     public $notice = '';
 
+    /**
+     * @var int
+     */
+    public $duration = 3600; // 1 hour
+
     // Public Methods
     // =========================================================================
 
@@ -60,6 +65,8 @@ class Settings extends Model
             [['password'], 'required'],
             ['notice', 'string'],
             ['notice', 'default', 'value' => ''],
+            ['duration', 'integer'],
+            ['duration', 'default', 'value' => 3600],
         ];
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -30,6 +30,11 @@ class Settings extends Model
     // =========================================================================
 
     /**
+     * @var bool
+     */
+    public $enabled = true;
+
+    /**
      * @var string
      */
     public $password = '';
@@ -60,6 +65,8 @@ class Settings extends Model
     public function rules()
     {
         return [
+            ['enabled', 'integer'],
+            ['enabled', 'default', 'value' => 0],
             ['password', 'string', 'min' => 8],
             ['password', 'default', 'value' => ''],
             [['password'], 'required'],

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -37,3 +37,30 @@
     value: settings.notice,
     errors: settings.getErrors("notice"),
 }) }}
+
+{{ forms.selectField({
+    label: "Duration"|t("gatekeeper"),
+    instructions: "Choose how long the user will have access to the website before they will have to re-input the password."|t("gatekeeper"),
+    id: "duration",
+    name: "duration",
+    options: [
+        {
+            label: "1 hour",
+            value: 3600,
+        },
+        {
+            label: "1 day",
+            value: 86400
+        },
+        {
+            label: "30 days",
+            value: 2592000
+        },
+        {
+            label: "1 year",
+            value: 31536000
+        }
+    ],
+    value: settings.duration,
+    errors: settings.getErrors("duration"),
+}) }}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -15,6 +15,16 @@
 
 {% import "_includes/forms" as forms %}
 
+{% macro configWarning(setting) -%}
+  {% set setting = '<code>' ~ setting ~ '</code>' %}
+  {{ 'This is being overridden by the {setting} config setting in your {file} config file.'|t('gatekeeper', {
+        setting: setting,
+        file: 'gatekeeper.php'
+  })|raw }}
+{%- endmacro %}
+
+{% from _self import configWarning %}
+
 {% do view.registerAssetBundle("tomdiggle\\gatekeeper\\assetbundles\\gatekeeper\\GatekeeperAsset") %}
 
 {{ forms.lightswitchField({
@@ -25,6 +35,7 @@
     value: 1,
     on: settings.enabled,
     errors: settings.getErrors("enabled"),
+    warning: "enabled" in overrides ? configWarning("enabled"),
 }) }}
 
 {{ forms.textField({
@@ -36,6 +47,7 @@
     required: true,
     value: settings.password,
     errors: settings.getErrors("password"),
+    warning: "password" in overrides ? configWarning("password"),
 }) }}
 
 {{ forms.textField({
@@ -46,7 +58,9 @@
     name: "notice",
     value: settings.notice,
     errors: settings.getErrors("notice"),
+    warning: "notice" in overrides ? configWarning("notice"),
 }) }}
+
 
 {{ forms.selectField({
     label: "Duration"|t("gatekeeper"),
@@ -73,4 +87,5 @@
     ],
     value: settings.duration,
     errors: settings.getErrors("duration"),
+    warning: "duration" in overrides ? configWarning("duration"),
 }) }}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -17,6 +17,16 @@
 
 {% do view.registerAssetBundle("tomdiggle\\gatekeeper\\assetbundles\\gatekeeper\\GatekeeperAsset") %}
 
+{{ forms.lightswitchField({
+    label: "Enabled"|t("gatekeeper"),
+    instructions: "Whether Gatekeeper protection should be on or off."|t("gatekeeper"),
+    id: "enabled",
+    name: "enabled",
+    value: 1,
+    on: settings.enabled,
+    errors: settings.getErrors("enabled"),
+}) }}
+
 {{ forms.textField({
     label: "Password"|t("gatekeeper"),
     instructions: "Enter the password required to access the website."|t("gatekeeper"),


### PR DESCRIPTION
A couple of updates to make configuration a bit more flexible:

- Add 2 new settings: 'enabled' (fix for #7 ) and 'duration' (cookie expiration)
- Also display a warning on settings screen if values are being overridden in config file 